### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM maven:3-jdk-8-alpine
+LABEL name=paskal/pointim_bot
+LABEL maintainer="paskal.07@gmail.com"
+
+WORKDIR /usr/src
+RUN apk --no-cache --update add ca-certificates wget && \
+	update-ca-certificates && \
+	wget https://github.com/deemess/pointim_bot/archive/master.zip && \
+	unzip master.zip && \
+	cd /usr/src/pointim_bot-master && \
+	mvn package
+WORKDIR /usr/src/pointim_bot-master/target
+
+ENTRYPOINT java -Xms64M -Xmx64M -jar pointim_bot-1.0-SNAPSHOT.jar ${LOGIN}:${PASSWORD}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM maven:3-jdk-8-alpine
+# Build
+FROM maven:3-jdk-8-alpine AS build
 LABEL name=paskal/pointim_bot
 LABEL maintainer="paskal.07@gmail.com"
 
@@ -9,6 +10,17 @@ RUN apk --no-cache --update add ca-certificates wget && \
 	unzip master.zip && \
 	cd /usr/src/pointim_bot-master && \
 	mvn package
-WORKDIR /usr/src/pointim_bot-master/target
 
+# Run
+FROM openjdk:8-jdk-alpine
+
+COPY --from=build /usr/src/pointim_bot-master/target /usr/pointim_bot
+# dirty hack for https://github.com/deemess/pointim_bot/issues/10
+COPY --from=build /usr/src/pointim_bot-master/log4j.xml /usr/pointim_bot/
+
+WORKDIR /usr/pointim_bot
+
+RUN apk add --update ca-certificates && update-ca-certificates
+
+# $LOGIN and $PASSWORD taken from env inside docker
 ENTRYPOINT java -Xms64M -Xmx64M -jar pointim_bot-1.0-SNAPSHOT.jar ${LOGIN}:${PASSWORD}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Point.im telegram
+
+pointim_bot is a telegram bot for point.im micro blogging service.
+
+## Docker run instructions
+
+1. Build or pull docker image:
+	- `docker pull paskal/pointim_bot` or
+	- `docker-compose build`
+
+1. In `docker-compose.yml` file uncomment `volumes` and `environment` sections
+	- `/root/cache.bin` must be replaced to some persistent folder noone else have access to on your server
+	- `LOGIN` and `PASSWORD` are left and right [token parts](https://core.telegram.org/bots#6-botfather) of your bot
+
+1. Run service with command `docker-compose up -d`, inspect it's state with `docker-compose logs`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+services:
+
+
+    pointim_bot:
+        build: ./
+        image: paskal/pointim_bot
+        hostname: pointim_bot
+        restart: always
+        container_name: pointim_bot
+
+        logging:
+          driver: json-file
+          options:
+              max-size: "10m"
+              max-file: "5"
+
+        # persistent cache, set a proper location for it
+        # volumes:
+        #     - /root/cache.bin:/usr/pointim_bot/cache.bin
+
+        # telegram login and password
+        # environment:
+        #     - LOGIN=<12345678910>
+        #     - PASSWORD=<long_password_here>


### PR DESCRIPTION
I already have this working, I guess it should stay near the code so if someone want to run it, they will have such ability.
Makefile instructions:
```
# build docker image
build_image:
	docker build -t paskal/pointim_bot pointim_bot

run_pointim_bot:
	. ../credentials.conf && \
	docker run -d --restart=always \
		--mount type=bind,source=/root/cache.bin,target=/usr/src/pointim_bot-master/target/cache.bin \
		-e LOGIN="$${POINT_BOT_LOGIN}" \
		-e PASSWORD="$${POINT_BOT_PASSWORD}" \
		paskal/pointim_bot
```
- `cache.bin` used for sessions cache
- `credentials.conf` contain two lines:
```
POINT_BOT_LOGIN="login"
POINT_BOT_PASSWORD="password"
```